### PR TITLE
Add aria label support for sidemenu buttons

### DIFF
--- a/src/scripts/mdSidemenuButton/index.js
+++ b/src/scripts/mdSidemenuButton/index.js
@@ -8,6 +8,7 @@ let directive = () => {
     scope: {
       uiSref: '@?',
       uiSrefActive: '@?',
+      ariaLabel: '@?',
       href: '@?',
       target: '@?'
     },

--- a/src/scripts/mdSidemenuButton/template.js
+++ b/src/scripts/mdSidemenuButton/template.js
@@ -7,6 +7,7 @@ export default function() {
       href="{{ $mdSidemenuButton.href }}"
       ui-sref="{{ $mdSidemenuButton.uiSref }}"
       ui-sref-active="{{ $mdSidemenuButton.uiSrefActive }}"
+      aria-label="{{ $mdSidemenuButton.ariaLabel }}"
       target="{{ $mdSidemenuButton.target }}">
       <div layout="row" layout-fill layout-align="start center" ng-transclude></div>
     </md-button>


### PR DESCRIPTION
Currently without the aria label being mapped for sidemenu buttons that are links, there is an informational log from angular material saying that the links should have aria labels.